### PR TITLE
Skip image generation when no WebSocket clients connected

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,6 +122,12 @@ func main() {
 			case <-timerCh:
 				// Deferred timer fired — generate with the latest pending data
 				if pendingRecent != nil {
+					if !srv.HasClients() {
+						Debugf("no WebSocket clients connected, skipping deferred generation")
+						pendingRecent = nil
+						pendingPath = ""
+						continue
+					}
 					Debugf("deferred generation triggered")
 					lastGenTime = time.Now()
 					recent := pendingRecent
@@ -152,6 +158,12 @@ func main() {
 				}
 
 				recent := TailMessages(messages, cfg.RecentMessages)
+
+				// Skip generation when no WebSocket clients are connected
+				if !srv.HasClients() {
+					Debugf("no WebSocket clients connected, skipping image generation")
+					continue
+				}
 
 				now := time.Now()
 				if now.Sub(lastGenTime) >= cfg.GenerateInterval {

--- a/server.go
+++ b/server.go
@@ -35,6 +35,13 @@ func NewServer(port, imageDir string, done <-chan struct{}) *Server {
 	}
 }
 
+// HasClients returns true if at least one WebSocket client is connected.
+func (s *Server) HasClients() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.clients) > 0
+}
+
 // Broadcast sends the image filename to all connected WebSocket clients.
 func (s *Server) Broadcast(filename string) {
 	s.mu.RLock()


### PR DESCRIPTION
## Summary
- WebSocketクライアント（ブラウザ）が接続されていない場合、画像生成をスキップするように変更
- `Server.HasClients()` メソッドを追加し、接続中クライアントの有無をスレッドセーフにチェック
- 即時生成パス・遅延生成パスの両方でチェックを実施し、プロンプト生成APIと画像生成APIの無駄な呼び出しを防止

## Test plan
- [x] クライアント未接続の状態で会話を更新し、画像生成がスキップされることをDEBUGログで確認
- [x] クライアント接続中に会話を更新し、画像が正常に生成・配信されることを確認
- [x] クライアント接続→切断→会話更新の順で、スキップされることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)